### PR TITLE
Add params to topic_posts

### DIFF
--- a/lib/discourse_api/api/topics.rb
+++ b/lib/discourse_api/api/topics.rb
@@ -25,18 +25,18 @@ module DiscourseApi
       end
 
       def latest_topics(params = {})
-        response = get('/latest.json', params)
-        response[:body]['topic_list']['topics']
+        response = get("/latest.json", params)
+        response[:body]["topic_list"]["topics"]
       end
 
       def top_topics(params = {})
         response = get("/top.json", params)
-        response[:body]['topic_list']['topics']
+        response[:body]["topic_list"]["topics"]
       end
 
       def new_topics(params = {})
         response = get("/new.json", params)
-        response[:body]['topic_list']['topics']
+        response[:body]["topic_list"]["topics"]
       end
 
       def rename_topic(topic_id, title)
@@ -49,7 +49,7 @@ module DiscourseApi
 
       # TODO: Deprecated. Remove after 20201231
       def change_topic_status(topic_slug, topic_id, params = {})
-        deprecated(__method__, 'update_topic_status')
+        deprecated(__method__, "update_topic_status")
         update_topic_status(topic_id, params)
       end
 
@@ -74,13 +74,13 @@ module DiscourseApi
         delete("/t/#{id}.json")
       end
 
-      def topic_posts(topic_id, post_ids = [])
+      def topic_posts(topic_id, post_ids = [], params = {})
         url = ["/t/#{topic_id}/posts.json"]
         if post_ids.count > 0
           url.push('?')
           url.push(post_ids.map { |id| "post_ids[]=#{id}" }.join('&'))
         end
-        response = get(url.join)
+        response = get(url.join, params)
         response[:body]
       end
 

--- a/spec/discourse_api/api/topics_spec.rb
+++ b/spec/discourse_api/api/topics_spec.rb
@@ -170,6 +170,14 @@ describe DiscourseApi::API::Topics do
       expect(body['post_stream']['posts']).to be_an Array
       expect(body['post_stream']['posts'].first).to be_a Hash
     end
+
+    it "can pass params " do
+      body = subject.topic_posts(57, [123], {include_raw: true})
+      expect(body).to be_a Hash
+      expect(body['post_stream']['posts']).to be_an Array
+      expect(body['post_stream']['posts'].first).to be_a Hash
+      expect(body['post_stream']['posts'].first['raw']).to be_an Array
+    end
   end
 
   describe "#create_topic_with_tags" do

--- a/spec/fixtures/topic_posts.json
+++ b/spec/fixtures/topic_posts.json
@@ -34,6 +34,7 @@
         "read":true,
         "user_title":null,
         "actions_summary":[{"id":2,"count":3,"can_act":true}],
+        "raw": [{"type":"paragraph","children":[{"text":"This is a raw post  I've got white   space!... and emojis 😈😈😈😈😈😈"}]}],
         "moderator":false,
         "admin":false,
         "staff":false,


### PR DESCRIPTION
 Adds params to `topic_posts` endpoint to allow `include_raw: true` to be passed which will allow raw posts to be returned. 